### PR TITLE
エラーを回避するために、pumaのバージョン4.3.6をインストールするように変更。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'spring',        group: :development
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-gem 'puma'
+gem 'puma', '4.3.6'
 
 gem 'line-bot-api'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     pg (0.21.0)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-protection (2.0.8.1)
@@ -199,7 +199,7 @@ DEPENDENCIES
   line-bot-api
   listen
   pg (~> 0.18)
-  puma
+  puma (= 4.3.6)
   rails (~> 6.0.2)
   rails_12factor
   sass-rails


### PR DESCRIPTION
## 実装の背景・目的

最新版のXcodeをインストールした状態で`build install`を実行すると、pumaのインストールが失敗してしまうため、
インストールを可能にする。

## やったこと

- version 4.3.5ではなく、 version4.3.6のpumaをインストールするようにGemfileを変更しました。


## 補足

version 4.3.5 でも以下のコード

```
gem install puma:4.3.5 -- --with-cflags="-Wno-error=implicit-function-declaration"
```

を設定することでインストールすることはできますが、version4.3.6で修正されたため、
version4.3.6をインストールするようにしました。

## 参考文献

- https://github.com/puma/puma/issues/2304#issuecomment-687673420
- https://qiita.com/aiandrox/items/9389696ebc3cc6d3422e
