### PR TITLE
Level1 tokyo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# Ignore environment variables file
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,5 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+gem 'dotenv-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,10 +29,7 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           if event.message['text'] == '東京都'
-            message = {
-              type: 'text',
-              text: "2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
-            }
+            message['text'] = "2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
           end
         end
         client.reply_message(event['replyToken'], message)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,28 +22,20 @@ class WebhookController < ApplicationController
     events.each { |event|
       case event
       when Line::Bot::Event::Message
+        message = {
+          type: 'text',
+          text: '「東京都」と入力してください。'
+        }
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'] == '東京都' then
+          if event.message['text'] == '東京都'
             message = {
               type: 'text',
               text: "2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
             }
-            client.reply_message(event['replyToken'], message)
-          else
-            message = {
-              type: 'text',
-              text: '「東京都」と入力してください。'
-            }
-            client.reply_message(event['replyToken'], message)
           end
-        else
-          message = {
-            type: 'text',
-            text: '「東京都」と入力してください。'
-          }
-          client.reply_message(event['replyToken'], message)
         end
+        client.reply_message(event['replyToken'], message)
       end
     }
     head :ok

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,15 +24,25 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          if event.message['text'] == '東京都' then
+            message = {
+              type: 'text',
+              text: "2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
+            }
+            client.reply_message(event['replyToken'], message)
+          else
+            message = {
+              type: 'text',
+              text: '「東京都」と入力してください。'
+            }
+            client.reply_message(event['replyToken'], message)
+          end
+        else
           message = {
             type: 'text',
-            text: event.message['text']
+            text: '「東京都」と入力してください。'
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
         end
       end
     }


### PR DESCRIPTION
## 実装の背景・目的

Level1のステップ１として、「東京都」と入力した際にのみ、予め設定しておいた感染者情報を返すLINEボットを作成しました。

## やったこと

- ngrokを利用したテストを行うために、ローカルでも環境変数を使えるように変更。
  - "dotenv-rails"というgemを追加
  - アプリのルートディレクトリに.envファイルを追加
  - .env ファイル内にLINE_CHANNEL_SECRETとLINE_CHANNEL_TOKENを記載
  - .gitignoreに.envファイルを追加
- 「東京都」と入力した際に ”2020/11/18の感染者数200人累計感染者数4000人” という定型文を返すLINEボットを作成
- 「東京都」以外を入力した際に ”「東京都」と入力してください。” という定型文を返すLINEボットを作成

## 作成したラインボット
![image](https://user-images.githubusercontent.com/37490362/99483312-47711980-29a1-11eb-9fca-6e1f2b063cf8.png)
