### PR TITLE
Level1 all prefectures

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -18,18 +18,24 @@ class WebhookController < ApplicationController
       head 470
     end
 
+    prefectures = [
+      '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県',
+      '石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県',
+      '岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
+    ]
+
     events = client.parse_events_from(body)
     events.each { |event|
       case event
       when Line::Bot::Event::Message
         message = {
           type: 'text',
-          text: '「東京都」と入力してください。'
+          text: "都道府県名を入力してください。\n(例：福岡県)"
         }
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'] == '東京都'
-            message['text'] = "2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
+          if event.message['text'].in?(prefectures)
+            message['text'] = "#{event.message['text']}\n2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
           end
         end
         client.reply_message(event['replyToken'], message)


### PR DESCRIPTION
## 実装の背景・目的

東京都だけでなく全ての都道府県に対応できるように修正しました。

## やったこと

- 都道府県リストの作成
- 都道府県名が入力された場合、予め用意した感染者情報を返すLINEボットの作成

## デモ

![image](https://user-images.githubusercontent.com/37490362/99489725-b9e6f700-29ab-11eb-8346-c33a348051da.png)

