### PR TITLE
Level2 add covid api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,10 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  PREFECTURES = [
+    '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県',
+    '石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県',
+    '岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
+  ]
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-  PREFECTURES = [
-    '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県',
-    '石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県',
-    '岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
-  ]
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -12,6 +12,10 @@ class WebhookController < ApplicationController
       config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
     }
   end
+  
+  def infected_population(covid_info)
+    return covid_info["cases"] - covid_info["discharge"] - covid_info["deaths"]
+  end
 
   def callback
     body = request.body.read
@@ -21,11 +25,7 @@ class WebhookController < ApplicationController
       head 470
     end
 
-    prefectures = [
-      '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県',
-      '石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県',
-      '岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
-    ]
+    api_url = 'https://covid19-japan-web-api.now.sh/api/v1/prefectures'
 
     events = client.parse_events_from(body)
     events.each { |event|
@@ -37,29 +37,33 @@ class WebhookController < ApplicationController
         }
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'].in?(prefectures)
-            uri = URI.parse('https://covid19-japan-web-api.now.sh/api/v1/prefectures')
-            https = Net::HTTP.new(uri.host, uri.port);
-            https.use_ssl = uri.scheme === "https"
-
-            headers = { "Content-Type" => "application/json" }
-            request = Net::HTTP::Get.new(uri.path)
-            request.initialize_http_header(headers)
-            response = https.request(request)
+          if event.message['text'].in?(PREFECTURES)
+            uri = URI.parse(api_url)
+            response = Net::HTTP.get_response(uri)
 
             covid_json = response.read_body
             covid = JSON.parse(covid_json)
-            prefecture_id = prefectures.find_index { |n| n ==  event.message['text']}
+            prefecture_id = PREFECTURES.find_index(event.message['text'])
             
             update_date = covid[prefecture_id]["last_updated"]["cases_date"]
             update_date = update_date.to_s
-            update_date_year = update_date[0..3]
-            update_date_month = update_date[4..5]
-            update_date_day = update_date[6..]
+            update_date = Date.parse(update_date)
             
-            infected = covid[prefecture_id]["cases"] - covid[prefecture_id]["discharge"] - covid[prefecture_id]["deaths"]
-            
-            message['text'] = "#{event.message['text']}\n最終更新日\n#{update_date_year}/#{update_date_month}/#{update_date_day}\n現在の感染者数\n#{infected}人\n重症者数\n#{covid[prefecture_id]["severe"]}人\n死亡者数\n#{covid[prefecture_id]["deaths"]}人\n累計感染者数\n#{covid[prefecture_id]["cases"]}人"
+            infected = infected_population(covid[prefecture_id])
+
+            message['text'] = <<~EOS
+              #{event.message['text']}
+              最終更新日
+              #{update_date.year}/#{update_date.month}/#{update_date.day}
+              現在の感染者数
+              #{infected}人
+              重症者数
+              #{covid[prefecture_id]["severe"]}人
+              死亡者数
+              #{covid[prefecture_id]["deaths"]}人
+              累計感染者数
+              #{covid[prefecture_id]["cases"]}人
+            EOS
           end
         end
         client.reply_message(event['replyToken'], message)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,4 +1,7 @@
 require 'line/bot'
+require "uri"
+require "net/http"
+require "json"
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -35,7 +38,28 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           if event.message['text'].in?(prefectures)
-            message['text'] = "#{event.message['text']}\n2020/11/18の感染者数\n200人\n累計感染者数\n4000人"
+            uri = URI.parse('https://covid19-japan-web-api.now.sh/api/v1/prefectures')
+            https = Net::HTTP.new(uri.host, uri.port);
+            https.use_ssl = uri.scheme === "https"
+
+            headers = { "Content-Type" => "application/json" }
+            request = Net::HTTP::Get.new(uri.path)
+            request.initialize_http_header(headers)
+            response = https.request(request)
+
+            covid_json = response.read_body
+            covid = JSON.parse(covid_json)
+            prefecture_id = prefectures.find_index { |n| n ==  event.message['text']}
+            
+            update_date = covid[prefecture_id]["last_updated"]["cases_date"]
+            update_date = update_date.to_s
+            update_date_year = update_date[0..3]
+            update_date_month = update_date[4..5]
+            update_date_day = update_date[6..]
+            
+            infected = covid[prefecture_id]["cases"] - covid[prefecture_id]["discharge"] - covid[prefecture_id]["deaths"]
+            
+            message['text'] = "#{event.message['text']}\n最終更新日\n#{update_date_year}/#{update_date_month}/#{update_date_day}\n現在の感染者数\n#{infected}人\n重症者数\n#{covid[prefecture_id]["severe"]}人\n死亡者数\n#{covid[prefecture_id]["deaths"]}人\n累計感染者数\n#{covid[prefecture_id]["cases"]}人"
           end
         end
         client.reply_message(event['replyToken'], message)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -50,28 +50,25 @@ class WebhookController < ApplicationController
               prefecture = prefecture.chop
             end
 
-            for covid_prefecture in covid do
-              if covid_prefecture['name_ja'] == prefecture
-                update_date = covid_prefecture["last_updated"]["cases_date"]
-                update_date = update_date.to_s
-                update_date = Date.parse(update_date)
+            covid_prefecture = covid.find { |data| data['name_ja'] == prefecture }
 
-                message['text'] = <<~EOS
-                  #{event.message['text']}
-                  最終更新日
-                  #{update_date.strftime("%Y/%m/%d")}
-                  現在の感染者数
-                  #{infected_population(covid_prefecture)}人
-                  重症者数
-                  #{covid_prefecture["severe"]}人
-                  死亡者数
-                  #{covid_prefecture["deaths"]}人
-                  累計感染者数
-                  #{covid_prefecture["cases"]}人
-                EOS
-                break
-              end
-            end
+            update_date = covid_prefecture["last_updated"]["cases_date"]
+            update_date = update_date.to_s
+            update_date = Date.parse(update_date)
+
+            message['text'] = <<~EOS
+              #{event.message['text']}
+              最終更新日
+              #{update_date.strftime("%Y/%m/%d")}
+              現在の感染者数
+              #{infected_population(covid_prefecture)}人
+              重症者数
+              #{covid_prefecture["severe"]}人
+              死亡者数
+              #{covid_prefecture["deaths"]}人
+              累計感染者数
+              #{covid_prefecture["cases"]}人
+            EOS
           end
         end
         client.reply_message(event['replyToken'], message)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -39,19 +39,18 @@ class WebhookController < ApplicationController
         }
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'].in?(PREFECTURES)
-            uri = URI.parse(API_URL)
-            response = Net::HTTP.get_response(uri)
-            body = response.read_body
-            
-            covid = JSON.parse(body)
-            prefecture = event.message['text']
-            if prefecture != '北海道'
-              prefecture = prefecture.chop
-            end
+          uri = URI.parse(API_URL)
+          response = Net::HTTP.get_response(uri)
+          body = response.read_body
+          
+          covid = JSON.parse(body)
+          prefecture = event.message['text']
+          if prefecture != '北海道'
+            prefecture = prefecture.chop
+          end
 
-            covid_prefecture = covid.find { |data| data['name_ja'] == prefecture }
-
+          covid_prefecture = covid.find { |data| data['name_ja'] == prefecture }
+          if covid_prefecture
             update_date = covid_prefecture["last_updated"]["cases_date"]
             update_date = update_date.to_s
             update_date = Date.parse(update_date)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -6,15 +6,19 @@ require "json"
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
+  PREFECTURES = [
+    '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県',
+    '石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県',
+    '岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
+  ]
+
+  API_URL = 'https://covid19-japan-web-api.now.sh/api/v1/prefectures'
+
   def client
     @client ||= Line::Bot::Client.new { |config|
       config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
       config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
     }
-  end
-  
-  def infected_population(covid_info)
-    return covid_info["cases"] - covid_info["discharge"] - covid_info["deaths"]
   end
 
   def callback
@@ -24,8 +28,6 @@ class WebhookController < ApplicationController
     unless client.validate_signature(body, signature)
       head 470
     end
-
-    api_url = 'https://covid19-japan-web-api.now.sh/api/v1/prefectures'
 
     events = client.parse_events_from(body)
     events.each { |event|
@@ -38,32 +40,38 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           if event.message['text'].in?(PREFECTURES)
-            uri = URI.parse(api_url)
+            uri = URI.parse(API_URL)
             response = Net::HTTP.get_response(uri)
-
-            covid_json = response.read_body
-            covid = JSON.parse(covid_json)
-            prefecture_id = PREFECTURES.find_index(event.message['text'])
+            body = response.read_body
             
-            update_date = covid[prefecture_id]["last_updated"]["cases_date"]
-            update_date = update_date.to_s
-            update_date = Date.parse(update_date)
-            
-            infected = infected_population(covid[prefecture_id])
+            covid = JSON.parse(body)
+            prefecture = event.message['text']
+            if prefecture != '北海道'
+              prefecture = prefecture.chop
+            end
 
-            message['text'] = <<~EOS
-              #{event.message['text']}
-              最終更新日
-              #{update_date.year}/#{update_date.month}/#{update_date.day}
-              現在の感染者数
-              #{infected}人
-              重症者数
-              #{covid[prefecture_id]["severe"]}人
-              死亡者数
-              #{covid[prefecture_id]["deaths"]}人
-              累計感染者数
-              #{covid[prefecture_id]["cases"]}人
-            EOS
+            for covid_prefecture in covid do
+              if covid_prefecture['name_ja'] == prefecture
+                update_date = covid_prefecture["last_updated"]["cases_date"]
+                update_date = update_date.to_s
+                update_date = Date.parse(update_date)
+
+                message['text'] = <<~EOS
+                  #{event.message['text']}
+                  最終更新日
+                  #{update_date.strftime("%Y/%m/%d")}
+                  現在の感染者数
+                  #{infected_population(covid_prefecture)}人
+                  重症者数
+                  #{covid_prefecture["severe"]}人
+                  死亡者数
+                  #{covid_prefecture["deaths"]}人
+                  累計感染者数
+                  #{covid_prefecture["cases"]}人
+                EOS
+                break
+              end
+            end
           end
         end
         client.reply_message(event['replyToken'], message)
@@ -71,4 +79,10 @@ class WebhookController < ApplicationController
     }
     head :ok
   end
+
+  private
+  def infected_population(covid_info)
+    return covid_info["cases"] - covid_info["discharge"] - covid_info["deaths"]
+  end
+
 end


### PR DESCRIPTION
## 実装の背景・目的

このAPI
https://covid19-japan-web-api.now.sh/api/v1/prefectures
を用いて、最新の感染者情報を取得し、出力するLINEボットを作成すること。

## やったこと

- https://covid19-japan-web-api.now.sh/api/v1/prefectures を用いて感染者情報を取得
- 次の情報をLINEボットで応答するような機能を追加
  - 最終更新日
  - 現在の感染者数（累計感染者数 - 回復者数 - 死亡者数）
  - 重症者数
  - 死亡者数
  - 累計感染者数

## デモ

![image](https://user-images.githubusercontent.com/37490362/99501974-d1c87600-29bf-11eb-83e5-f8b3696bbaed.png)

